### PR TITLE
Fixes hardcoded wait time for data to be ready

### DIFF
--- a/AD7192/src/ad7192.cpp
+++ b/AD7192/src/ad7192.cpp
@@ -175,7 +175,7 @@ uint32_t ad7192ReadADCChannelData(uint8_t channel)  {
     uint32_t rawConvertData = 0;
     ad7192SetChannel(channel);                  // set one channel to be selected
     ad7192StartSingleConversion();              // write command to initial conversion mode
-    delay(10);                                  // TODO: hardcoded wait time for data to be ready
+    delay(100);                                 // TODO: hardcoded wait time for data to be ready
     rawConvertData = ad7192ReadConvertingData();// read raw convertible data from ADC
     return rawConvertData;
 }


### PR DESCRIPTION
### Problem

Fixes hardcoded wait time for data to be ready when multiple-channels switch to read ADC!

### Solution

Software workaround: add more long waiting time for ADC data ready.

### Steps to Test

NA

### Example App

```c
void setup() {
    ad7192Init();
    ad7192SetPGAGain(1);
    ad7192SetFilterSelectBit(100);
    ad7192InternalZeroFullScaleCalibration();
}

void loop() {
    // Test ADC CH1 raw data to convert voltage
    uint32_t rawData1 = ad7192ReadADCChannelData(AD7192_CH_AIN1);
    float volt1 = ad7192RawDataToVoltage(rawData1);
    Log.info("CH1 data: %lx, Voltage Measurement: %fmV", rawData1, volt1);
    
    uint32_t rawData2 = ad7192ReadADCChannelData(AD7192_CH_AIN2);
    float volt2 = ad7192RawDataToVoltage(rawData2);
    Log.info("CH2 data: %lx, Voltage Measurement: %fmV", rawData2, volt2);

    uint32_t rawData3 = ad7192ReadADCChannelData(AD7192_CH_AIN3);
    float volt3 = ad7192RawDataToVoltage(rawData3);
    Log.info("CH3 data: %lx, Voltage Measurement: %fmV", rawData3, volt3);

    uint32_t rawData4 = ad7192ReadADCChannelData(AD7192_CH_AIN4);
    float volt4 = ad7192RawDataToVoltage(rawData4);
    Log.info("CH4 data: %lx, Voltage Measurement: %fmV", rawData4, volt4);
    Log.info("----------------------------------------------------------");
    delay(1000);
}
```

### References
NA
